### PR TITLE
[TESTS] Add check ensuring that lesson defined in topic's json exists

### DIFF
--- a/checks/structure.py
+++ b/checks/structure.py
@@ -19,6 +19,7 @@ class TopicRange:
   lesson_start: str
   lesson_end: str
 
+
 @dataclass
 class Level:
   level: str
@@ -42,6 +43,7 @@ class Lesson:
 class LessonPrereq:
   lesson_id: str
   topic_id: str
+
 
 @dataclass
 class Topic:

--- a/checks/structure_loader.py
+++ b/checks/structure_loader.py
@@ -40,6 +40,7 @@ def load_level(course_id: str, level_id: str):
   except KeyError as e:
     assert False, f'Level {level} file for course {course_id} is malformed, cause: {repr(e)}'
 
+
 def load_topics(courses: [Course]):
   return dict([load_topics_for_course(course.id) for course in courses])
 
@@ -68,8 +69,15 @@ def load_topic(course_id: str, topic_id: str):
                       [LessonPrereq(prereq['lessonId'], prereq['topicId']) for prereq in
                        empty_if_none(lesson.get('prerequisites'))])
                for lesson in topic['lessons']]
+    for lesson in lessons:
+      ensure_lesson_presence(course_id, topic_id, lesson.id)
     return Topic(topic_id, topic['name'], topic['desc'], lessons)
   except FileNotFoundError:
     assert False, f'Topic {topic_id} index not found'
   except KeyError as e:
     assert False, f'Topic {topic_id} index is malformed, cause: {repr(e)}'
+
+
+def ensure_lesson_presence(course_id, topic_id, lesson_id):
+  path = f'{CONTENT_PATH}/topics/{topic_id}/{lesson_id}.md'
+  assert Path(path).is_file(), f'Lesson {course_id}/{topic_id}/{lesson_id} not found!'


### PR DESCRIPTION
An interesting case... we were not checking whether the lesson defined by the topic's JSON does actually exist among the lesson MD files. 

`E   AssertionError: Lesson scala/collections/streams not found!`
~ https://github.com/scalazone/scala/runs/2247251060?check_suite_focus=true#step:4:95

---
edit

whooops 
~and the same applies for `lessonStart` and `lessonEnd`~ 
nope, those work for coming soon lessons

---
edit

Okay I got it. `streams` is coming soon. it should have an empty file